### PR TITLE
Roll back Werkzeug from 1.0.0 to 0.16.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -35,7 +35,7 @@ Mako = "==1.0.7"
 MarkupSafe = "==1.1.1"
 PyJWT = "==1.7.1"
 SQLAlchemy = "==1.3.0"
-Werkzeug = "==1.0.0"
+Werkzeug = "==0.16.1"
 WTForms = "==2.2.1"
 
 [requires]


### PR DESCRIPTION
Roll back Werkzeug from 1.0.0 to 0.16.1 because of url_encode import deprecation that isn't supported by Flask-WTF